### PR TITLE
Moved intent-filter from main activity to JSActivity

### DIFF
--- a/app/alloy.js
+++ b/app/alloy.js
@@ -17,5 +17,7 @@ function handleIntent(intent) {
         Ti.API.error("GOT DEEPLINK INTENT WE WANTED...:"+DEEPLINK);
     }
 }
-Ti.Android.rootActivity.addEventListener("newintent", handleIntent);
+Ti.Android.rootActivity.addEventListener("newintent", function(e) {
+    handleIntent(e.intent);
+});
 handleIntent(Ti.Android.rootActivity.intent);

--- a/app/lib/ActivityDeepLink.js
+++ b/app/lib/ActivityDeepLink.js
@@ -1,0 +1,2 @@
+
+Ti.API.info("Deep-Linking Intent Received.");

--- a/tiapp.xml
+++ b/tiapp.xml
@@ -42,25 +42,18 @@
       </dict>
     </plist>
   </ios>
-  <android 
-    xmlns:android="http://schemas.android.com/apk/res/android">
-    <manifest 
-      xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1">
-      <application android:icon="@drawable/appicon" android:label="newapp" android:name="NewappApplication" android:debuggable="false" android:usesCleartextTraffic="true" android:theme="@style/Theme.AppCompat" android:resizeableActivity="true">
-        <activity android:name=".NewappActivity" android:label="@string/app_name" android:theme="@style/Theme.Titanium" android:alwaysRetainTaskState="true" android:configChanges="keyboardHidden|orientation|fontScale|screenSize|smallestScreenSize|screenLayout|density">
-          <intent-filter>
-            <action android:name="android.intent.action.MAIN"/>
-            <category android:name="android.intent.category.LAUNCHER"/>
-          </intent-filter>
-          <intent-filter>
-            <action android:name="android.intent.action.VIEW"/>
-            <category android:name="android.intent.category.DEFAULT"/>
-            <category android:name="android.intent.category.BROWSABLE"/>
-            <data android:host="deep-link" scheme="newapp"/>
-          </intent-filter>
-        </activity>
-      </application>
-    </manifest>
+  <android xmlns:android="http://schemas.android.com/apk/res/android">
+    <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1"/>
+    <activities>
+      <activity android:exported="true" url="ActivityDeepLink.js">
+        <intent-filter>
+          <action android:name="android.intent.action.VIEW"/>
+          <category android:name="android.intent.category.DEFAULT"/>
+          <category android:name="android.intent.category.BROWSABLE"/>
+          <data android:host="deep-link" scheme="newapp"/>
+        </intent-filter>
+      </activity>
+    </activities>
   </android>
   <modules/>
   <deployment-targets>


### PR DESCRIPTION
**Summary:**
- Works-around "FLAG_ACTIVITY_CLEAR_TOP" intent issue where it restarts the app.
  * This flag tells the Android OS to destroy all child windows, which effectively restarts the app.
  * Added JSActivity to receive intent. As of Titanium 8.0.0, it'll always destroy itself, resume the existing app, and pass it the intent.
  * This intent flag can't hurt a JSActivity since it is never displayed. This activity is an invisible pass-through for intents.
- Fixed bug with "alloy.js" file's "newintent" listener which was passing "event" object instead of "intent" object to handleIntent() method.
